### PR TITLE
components: iterate on the each object

### DIFF
--- a/components.tfstack.hcl
+++ b/components.tfstack.hcl
@@ -19,7 +19,7 @@ component "lambda" {
   source = "./lambda"
 
   inputs = {
-    region    = var.regions
+    region    = each.value
     prefix    = var.prefix
     bucket_id = component.s3[each.value].bucket_id
   }


### PR DESCRIPTION
In blocks where `for_each` is set, an additional `each` object is available in expressions.

This appears to be a typo based on the rest of the code in the stack. Please note that merging this could trigger a full redeployment of this component.